### PR TITLE
[run-tests][fix][cli] Quit PerformanceConsumer after receiving numMessages messages 

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -315,6 +315,12 @@ public class PerformanceConsumer {
                 totalMessagesReceived.increment();
                 totalBytesReceived.add(msg.size());
 
+                if (arguments.numMessages > 0 && totalMessagesReceived.sum() >= arguments.numMessages) {
+                    log.info("------------------- DONE -----------------------");
+                    PerfClientUtils.exit(0);
+                    thread.interrupt();
+                }
+
                 if (limiter != null) {
                     limiter.acquire();
                 }

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PerfToolTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/PerfToolTest.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.cli;
+
+import static org.testng.Assert.fail;
+import org.apache.pulsar.tests.integration.containers.ChaosContainer;
+import org.apache.pulsar.tests.integration.containers.PulsarContainer;
+import org.apache.pulsar.tests.integration.containers.ZKContainer;
+import org.apache.pulsar.tests.integration.docker.ContainerExecResult;
+import org.apache.pulsar.tests.integration.messaging.TopicMessagingBase;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class PerfToolTest extends TopicMessagingBase {
+
+    private static final int MESSAGE_COUNT = 50;
+
+    @Test
+    private void testProduce() throws Exception {
+        String serviceUrl = "pulsar://" + pulsarCluster.getProxy().getContainerName() + ":" + PulsarContainer.BROKER_PORT;
+        final String topicName = getNonPartitionedTopic("testProduce", true);
+        // Using the ZK container as it is separate from brokers, so its environment resembles real world usage more
+        ZKContainer<?> clientToolContainer = pulsarCluster.getZooKeeper();
+        ContainerExecResult produceResult = produceWithPerfTool(clientToolContainer, serviceUrl, topicName);
+        checkOutputForLogs(produceResult,"PerformanceProducer - Aggregated throughput stats",
+                "PerformanceProducer - Aggregated latency stats");
+    }
+
+    @Test
+    private void testConsume() throws Exception {
+        String serviceUrl = "pulsar://" + pulsarCluster.getProxy().getContainerName() + ":" + PulsarContainer.BROKER_PORT;
+        final String topicName = getNonPartitionedTopic("testConsume", true);
+        // Using the ZK container as it is separate from brokers, so its environment resembles real world usage more
+        ZKContainer<?> clientToolContainer = pulsarCluster.getZooKeeper();
+        ContainerExecResult consumeResult = consumeWithPerfTool(clientToolContainer, serviceUrl, topicName);
+        checkOutputForLogs(consumeResult,"PerformanceConsumer - Aggregated throughput stats",
+                "PerformanceConsumer - Aggregated latency stats");
+    }
+
+    private ContainerExecResult produceWithPerfTool(ChaosContainer<?> container, String url, String topic) throws Exception {
+        ContainerExecResult result = container.execCmd("bin/pulsar-perf", "produce", "-u", url, "-m", String.valueOf(MESSAGE_COUNT), topic);
+
+        return failOnError("Performance producer", result);
+    }
+
+    private ContainerExecResult consumeWithPerfTool(ChaosContainer<?> container, String url, String topic) throws Exception {
+        CompletableFuture<ContainerExecResult> resultFuture =
+                container.execCmdAsync("bin/pulsar-perf", "consume", "-u", url, "-m", String.valueOf(MESSAGE_COUNT), topic);
+        produceWithPerfTool(container, url, topic);
+
+        ContainerExecResult result = resultFuture.get(5, TimeUnit.SECONDS);
+        return failOnError("Performance consumer", result);
+    }
+
+    private static ContainerExecResult failOnError(String processDesc, ContainerExecResult result) {
+        if (result.getExitCode() != 0) {
+            fail(processDesc + " failed. Command output:\n" + result.getStdout()
+                    + "\nError output:\n" + result.getStderr());
+        }
+        return result;
+    }
+
+    private static void checkOutputForLogs(ContainerExecResult result, String... logs) {
+        String output = result.getStdout();
+        for (String log : logs) {
+            Assert.assertTrue(output.contains(log),
+                    "command output did not contain log message '" + log + "'.\nFull stdout is:\n" + output);
+        }
+    }
+
+}

--- a/tests/integration/src/test/resources/pulsar-cli.xml
+++ b/tests/integration/src/test/resources/pulsar-cli.xml
@@ -31,6 +31,7 @@
             <class name="org.apache.pulsar.tests.integration.cli.PackagesCliTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.PulsarVersionTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.tenant.TenantTest"/>
+            <class name="org.apache.pulsar.tests.integration.cli.PerfToolTest"/>
             <class name="org.apache.pulsar.tests.integration.cli.topicpolicies.SchemaCompatibilityStrategyTest"/>
         </classes>
     </test>


### PR DESCRIPTION
Fixes #17747

### Motivation

`PerformanceConsumer` command line tool does not use its `-m` flag thus misleading its users.

### Modifications

Check the total number of messages received against `numMessages` if the latter is non-zero.
Added integration test for `pulsar-perf` tool.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change can be verified as follows:

  - Added integration test.

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
This is a bugfix

- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)

### Matching PR in forked repository

PR in forked repository: https://github.com/andrasbeni/pulsar/pull/3
