### PR TITLE
[improve][meta]Allow version to start positive and grow by more than one

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Stat.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/api/Stat.java
@@ -19,12 +19,19 @@
 package org.apache.pulsar.metadata.api;
 
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Represent the information associated with a given value in the store.
  */
 @Data
+@RequiredArgsConstructor
 public class Stat {
+
+    public Stat(String path, long version, long creationTimestamp, long modificationTimestamp, boolean ephemeral,
+                boolean createdBySelf) {
+        this(path, version, creationTimestamp, modificationTimestamp, ephemeral, createdBySelf, version == 0);
+    }
 
     /**
      * The path of the value.
@@ -55,4 +62,9 @@ public class Stat {
      * Whether the key-value pair had been created within the current "session".
      */
     final boolean createdBySelf;
+
+    /**
+     * Whether this is the first version of the key-value pair since it has been last created.
+     */
+    final boolean firstVersion;
 }

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/AbstractMetadataStore.java
@@ -466,7 +466,7 @@ public abstract class AbstractMetadataStore implements MetadataStoreExtended, Co
         return storePut(path, data, optExpectedVersion,
                 (options != null && !options.isEmpty()) ? EnumSet.copyOf(options) : EnumSet.noneOf(CreateOption.class))
                 .thenApply(stat -> {
-                    NotificationType type = stat.getVersion() == 0 ? NotificationType.Created
+                    NotificationType type = stat.isFirstVersion() ? NotificationType.Created
                             : NotificationType.Modified;
                     if (type == NotificationType.Created) {
                         existsCache.synchronous().invalidate(path);

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataCacheTest.java
@@ -290,7 +290,9 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         assertEquals(objCache.get(key1).join(), Optional.empty());
 
         MyClass value1 = new MyClass("a", 1);
-        store.put(key1, ObjectMapperFactory.getMapper().writer().writeValueAsBytes(value1), Optional.of(-1L)).join();
+        Stat putResult = store.put(key1, ObjectMapperFactory.getMapper().writer().writeValueAsBytes(value1),
+                Optional.of(-1L)).join();
+        assertTrue(putResult.isFirstVersion());
 
         Awaitility.await().untilAsserted(() -> {
             assertEquals(objCache.getIfCached(key1), Optional.of(value1));
@@ -298,7 +300,8 @@ public class MetadataCacheTest extends BaseMetadataStoreTest {
         });
 
         MyClass value2 = new MyClass("a", 2);
-        store.put(key1, ObjectMapperFactory.getMapper().writer().writeValueAsBytes(value2), Optional.of(0L)).join();
+        store.put(key1, ObjectMapperFactory.getMapper().writer().writeValueAsBytes(value2),
+                Optional.of(putResult.getVersion())).join();
 
         Awaitility.await().untilAsserted(() -> {
             assertEquals(objCache.getIfCached(key1), Optional.of(value2));

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreBatchingTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreBatchingTest.java
@@ -104,7 +104,8 @@ public class MetadataStoreBatchingTest extends BaseMetadataStoreTest {
         CompletableFuture<Stat> f3 = store.put(key1 + "/c", new byte[0], Optional.of(-1L)); // Should succeed
         CompletableFuture<Void> f4 = store.delete(key1 + "/d", Optional.empty()); // Should fail
 
-        assertEquals(f1.join().getVersion(), 0L);
+        assertTrue(f1.join().getVersion() >= 0L);
+        assertTrue(f1.join().isFirstVersion());
 
         try {
             f2.join();
@@ -112,7 +113,9 @@ public class MetadataStoreBatchingTest extends BaseMetadataStoreTest {
             assertEquals(ce.getCause().getClass(), BadVersionException.class);
         }
 
-        assertEquals(f3.join().getVersion(), 0L);
+        assertTrue(f3.join().getVersion() >= 0L);
+        assertTrue(f3.join().isFirstVersion());
+
 
         try {
             f4.join();

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreExtendedTest.java
@@ -45,7 +45,8 @@ public class MetadataStoreExtendedTest extends BaseMetadataStoreTest {
         Stat stat1 = store.put(basePath, "value-1".getBytes(), Optional.of(-1L), EnumSet.of(CreateOption.Sequential))
                 .join();
         assertNotNull(stat1);
-        assertEquals(stat1.getVersion(), 0L);
+        assertTrue(stat1.getVersion() >= 0L);
+        assertTrue(stat1.isFirstVersion());
         assertNotEquals(stat1.getPath(), basePath);
         assertEquals(store.get(stat1.getPath()).join().get().getValue(), "value-1".getBytes());
         String seq1 = stat1.getPath().replace(basePath, "");
@@ -54,7 +55,8 @@ public class MetadataStoreExtendedTest extends BaseMetadataStoreTest {
         Stat stat2 = store.put(basePath, "value-2".getBytes(), Optional.of(-1L), EnumSet.of(CreateOption.Sequential))
                 .join();
         assertNotNull(stat2);
-        assertEquals(stat2.getVersion(), 0L);
+        assertTrue(stat2.getVersion() >= 0L);
+        assertTrue(stat2.isFirstVersion());
         assertNotEquals(stat2.getPath(), basePath);
         assertNotEquals(stat2.getPath(), stat1.getPath());
         assertEquals(store.get(stat2.getPath()).join().get().getValue(), "value-2".getBytes());


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://docs.google.com/document/d/1d8Pw6ZbWk-_pCKdOmdvx9rnhPiyuxwq60_TrD68d7BA/edit#heading=h.trs9rsex3xom)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->
### Motivation

All currently available MetadataStore implementations assign versions to key-value pairs the same way: when a new pair is created, it is assigned version 0, and each subsequent modification increases the version by one. Actually, Pulsar does not need such a strict versioning scheme; it is enough that 
* all versions are positive
* later versions are greater
* the metadata store can inform us if a given Stat represents the first version.

### Modifications

Introduced Stat.isFirstVersion that practically defaults to version==0
Relaxed the requirements imposed by the tests only to test what is necessary for Pulsar.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is already covered by existing tests, such as the test modified by this PR.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
